### PR TITLE
Fix project card divider thickness

### DIFF
--- a/features/projects/components/project-card/project-card.tsx
+++ b/features/projects/components/project-card/project-card.tsx
@@ -39,7 +39,7 @@ const TopContainer = styled.div`
 
 const BottomContainer = styled.div`
   padding: ${space(4, 6)};
-  border-top: 3px solid ${color("gray", 200)};
+  border-top: 1px solid ${color("gray", 200)};
   display: flex;
   justify-content: flex-end;
 `;


### PR DESCRIPTION
This PR fixes the project card component divider thickness, setting it to 1 pixel as per Figma design.