### PR TITLE
Add custom hook to detect device orientation

### DIFF
--- a/custom-hooks/usehooks.tsx
+++ b/custom-hooks/usehooks.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+
+function useMediaQuery(query: string): boolean {
+  const getMatches = (query: string): boolean => {
+    // Prevents SSR issues
+    if (typeof window !== "undefined") {
+      return window.matchMedia(query).matches;
+    }
+    return false;
+  };
+
+  const [matches, setMatches] = useState<boolean>(getMatches(query));
+
+  function handleChange() {
+    setMatches(getMatches(query));
+  }
+
+  useEffect(() => {
+    const matchMedia = window.matchMedia(query);
+
+    // Triggered at the first client-side load and if query changes
+    handleChange();
+
+    // Listen matchMedia
+    // Note: addListener and removeListener are needed for Safari < 14. Remove them if the support is not needed.
+    if (matchMedia.addListener) {
+      matchMedia.addListener(handleChange);
+    } else {
+      matchMedia.addEventListener("change", handleChange);
+    }
+
+    return () => {
+      if (matchMedia.removeListener) {
+        matchMedia.removeListener(handleChange);
+      } else {
+        matchMedia.removeEventListener("change", handleChange);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query]);
+
+  return matches;
+}
+
+export { useMediaQuery };

--- a/features/layout/sidebar-navigation/navigation-context.tsx
+++ b/features/layout/sidebar-navigation/navigation-context.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from "react";
+import { useMediaQuery } from "../../../custom-hooks/usehooks";
+import { theme, breakpoint } from "@styles/theme";
 
 type NavigationContextProviderProps = {
   children: React.ReactNode;
@@ -6,6 +8,7 @@ type NavigationContextProviderProps = {
 
 const defaultContext = {
   isSidebarCollapsed: false,
+  isMobile: false,
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   toggleSidebar: () => {},
 };
@@ -18,11 +21,15 @@ export function NavigationProvider({
   const [isSidebarCollapsed, setSidebarCollapsed] = useState(
     defaultContext.isSidebarCollapsed
   );
+  const isMobile = !useMediaQuery(
+    `(min-width: ${breakpoint("desktop")({ theme })})`
+  );
 
   return (
     <NavigationContext.Provider
       value={{
         isSidebarCollapsed,
+        isMobile,
         toggleSidebar: () => setSidebarCollapsed((isCollapsed) => !isCollapsed),
       }}
     >

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -154,8 +154,10 @@ const CollapseMenuItem = styled(MenuItemButton)`
 
 export function SidebarNavigation() {
   const router = useRouter();
-  const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
+  const { isSidebarCollapsed, isMobile, toggleSidebar } =
+    useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+
   return (
     <Container isCollapsed={isSidebarCollapsed}>
       <FixedContainer>
@@ -163,7 +165,9 @@ export function SidebarNavigation() {
           <Logo
             src={
               isSidebarCollapsed
-                ? "/icons/logo-small.svg"
+                ? isMobile
+                  ? "/icons/logo-large.svg"
+                  : "/icons/logo-small.svg"
                 : "/icons/logo-large.svg"
             }
             alt="logo"


### PR DESCRIPTION
This PR fixes the navigation logo when switching to mobile, by adding a custom hook that detects the device orientation.
The isMobile variable has been added to the NavigationContext.