### PR TITLE
Fix color and display names of project status

### DIFF
--- a/api/projects.types.ts
+++ b/api/projects.types.ts
@@ -5,9 +5,9 @@ export enum ProjectLanguage {
 }
 
 export enum ProjectStatus {
-  stable = "stable",
+  stable = "info",
   warning = "warning",
-  critical = "critical",
+  critical = "error",
 }
 
 export type Project = {

--- a/cypress/e2e/project-list.cy.ts
+++ b/cypress/e2e/project-list.cy.ts
@@ -1,4 +1,3 @@
-import capitalize from "lodash/capitalize";
 import mockProjects from "../fixtures/projects.json";
 
 describe("Project List", () => {
@@ -22,17 +21,40 @@ describe("Project List", () => {
 
     it("renders the projects", () => {
       const languageNames = ["React", "Node.js", "Python"];
+      const statusMap = {
+        info: {
+          name: "Stable",
+          color: "rgb(2, 122, 72)",
+          bgColor: "rgb(236, 253, 243)",
+        },
+        warning: {
+          name: "Warning",
+          color: "rgb(181, 71, 8)",
+          bgColor: "rgb(255, 250, 235)",
+        },
+        error: {
+          name: "Critical",
+          color: "rgb(180, 35, 24)",
+          bgColor: "rgb(254, 243, 242)",
+        },
+      };
 
       // get all project cards
       cy.get("main")
         .find("li")
         .each(($el, index) => {
+          const statusInfo =
+            statusMap[mockProjects[index].status as keyof typeof statusMap];
+
           // check that project data is rendered
           cy.wrap($el).contains(mockProjects[index].name);
           cy.wrap($el).contains(languageNames[index]);
           cy.wrap($el).contains(mockProjects[index].numIssues);
           cy.wrap($el).contains(mockProjects[index].numEvents24h);
-          cy.wrap($el).contains(capitalize(mockProjects[index].status));
+          cy.wrap($el)
+            .contains(statusInfo.name)
+            .should("have.css", "color", statusInfo.color)
+            .and("have.css", "background-color", statusInfo.bgColor);
           cy.wrap($el)
             .find("a")
             .should("have.attr", "href", "/dashboard/issues");

--- a/features/projects/components/project-card/project-card.tsx
+++ b/features/projects/components/project-card/project-card.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import styled from "styled-components";
-import capitalize from "lodash/capitalize";
 import { Badge, BadgeColor } from "@features/ui";
 import { color, displayFont, space, textFont } from "@styles/theme";
 import { Routes } from "@config/routes";
@@ -21,6 +20,12 @@ const statusColors = {
   [ProjectStatus.stable]: BadgeColor.success,
   [ProjectStatus.warning]: BadgeColor.warning,
   [ProjectStatus.critical]: BadgeColor.error,
+};
+
+const statusNames = {
+  [ProjectStatus.stable]: "Stable",
+  [ProjectStatus.warning]: "Warning",
+  [ProjectStatus.critical]: "Critical",
 };
 
 const Container = styled.div`
@@ -123,7 +128,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
             <IssuesNumber>{numEvents24h}</IssuesNumber>
           </Issues>
           <Status>
-            <Badge color={statusColors[status]}>{capitalize(status)}</Badge>
+            <Badge color={statusColors[status]}>{statusNames[status]}</Badge>
           </Status>
         </InfoContainer>
       </TopContainer>


### PR DESCRIPTION
This PR fixes the project cards status, by updating ProjectStatus enum with the values obtained from the api call.